### PR TITLE
Jersey Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,14 +192,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.4.3</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.1</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0-beta-1</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.6.4</version>
+            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.6</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <name>Jeanfrancois Arcand</name>
             <email>jfarcand@apache.org</email>
         </developer>
+        <developer>
+            <id>simonetripodi</id>
+            <name>Simone Tripodi</name>
+            <email>simonetripodi@apache.org</email>
+        </developer>
     </developers>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         </license>
     </licenses>
     <properties>
-        <jersey.version>1.5</jersey.version>
+        <jersey.version>1.14</jersey.version>
     </properties>
     <dependencies>
         <dependency>
@@ -112,6 +112,12 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-bundle</artifactId>
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.sonatype.forge</groupId>
         <artifactId>forge-parent</artifactId>
-        <version>6</version>
+        <version>12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sonatype.spice</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.0.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <manifestLocation>META-INF</manifestLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -192,11 +192,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <encoding>UTF-8</encoding>
                     <maxmem>1024m</maxmem>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,19 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+    <properties>
+        <jersey.version>1.5</jersey.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.5</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-json</artifactId>
-            <version>1.5</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -104,7 +107,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.5</version>
+            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -201,20 +201,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
                     <encoding>UTF-8</encoding>
                     <maxmem>1024m</maxmem>
                 </configuration>

--- a/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcClientHandler.java
+++ b/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcClientHandler.java
@@ -105,7 +105,6 @@ public final class AhcClientHandler implements ClientHandler {
      * @return the {@link ClientResponse}
      * @throws ClientHandlerException
      */
-    @Override
     public ClientResponse handle(final ClientRequest cr)
             throws ClientHandlerException {
 

--- a/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcHttpClient.java
+++ b/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcHttpClient.java
@@ -149,7 +149,11 @@ public class AhcHttpClient extends Client {
             // Do not close the AHCClient.
             super.destroy();
         } finally {
-            super.finalize();            
+            try {
+                super.finalize();
+            } catch (Throwable e) {
+                // TODO swallow?
+            }
         }
     }
 

--- a/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
+++ b/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
@@ -54,7 +54,7 @@ public class AhcRequestWriter extends RequestWriter {
                 re.writeRequestEntity(new CommittingOutputStream(baos) {
                     @Override
                     protected void commit() throws IOException {
-                        configureHeaders(cr.getMetadata(), requestBuilder);
+                        configureHeaders(cr.getHeaders(), requestBuilder);
                     }
                 });
             } catch (IOException ex) {
@@ -68,7 +68,7 @@ public class AhcRequestWriter extends RequestWriter {
                 }
             });
         } else {
-            configureHeaders(cr.getMetadata(), requestBuilder);
+            configureHeaders(cr.getHeaders(), requestBuilder);
         }
     }
 

--- a/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
+++ b/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
@@ -61,13 +61,12 @@ public class AhcRequestWriter extends RequestWriter {
 
             final byte[] content = baos.toByteArray();
             requestBuilder.setBody(new Request.EntityWriter() {
-                @Override
                 public void writeEntity(OutputStream out) throws IOException {
                     out.write(content);
                 }
             });
         } else {
-            configureHeaders(cr.getMetadata(), requestBuilder);            
+            configureHeaders(cr.getMetadata(), requestBuilder);
         }
     }
 

--- a/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
+++ b/src/main/java/org/sonatype/spice/jersey/client/ahc/AhcRequestWriter.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.sonatype.spice.jersey.client.ahc;
 
+import static com.sun.jersey.api.client.ClientRequest.getHeaderValue;
+
 import com.ning.http.client.PerRequestConfig;
 import com.ning.http.client.Request;
 import com.ning.http.client.RequestBuilder;
@@ -77,7 +79,7 @@ public class AhcRequestWriter extends RequestWriter {
                 if (String.class.isAssignableFrom( o.getClass() )) {
                     requestBuilder.addHeader(e.getKey(), o.toString());
                 } else {
-                    requestBuilder.addHeader(e.getKey(), headerValueToString(o));
+                    requestBuilder.addHeader(e.getKey(), getHeaderValue(o));
                 }
             }
         }

--- a/src/test/java/org/sonatype/spice/jersey/client/ahc/tests/tests/AbstractGrizzlyServerTester.java
+++ b/src/test/java/org/sonatype/spice/jersey/client/ahc/tests/tests/AbstractGrizzlyServerTester.java
@@ -33,7 +33,7 @@ public abstract class AbstractGrizzlyServerTester extends TestCase {
     private SelectorThread selectorThread;
 
     private int port = getEnvVariable("JERSEY_HTTP_PORT", 9997);
-    
+
     private static int getEnvVariable(final String varName, int defaultValue) {
         if (null == varName) {
             return defaultValue;
@@ -52,26 +52,26 @@ public abstract class AbstractGrizzlyServerTester extends TestCase {
     public AbstractGrizzlyServerTester(String name) {
         super(name);
     }
-    
+
     public UriBuilder getUri() {
         return UriBuilder.fromUri("http://localhost").port(port).path(CONTEXT);
     }
-    
-    public void startServer(Class... resources) {
+
+    public void startServer(Class<?>... resources) {
         start(ContainerFactory.createContainer(Adapter.class, resources));
     }
-    
+
     public void startServer(ResourceConfig config) {
         start(ContainerFactory.createContainer(Adapter.class, config));
     }
-    
+
     private void start(Adapter adapter) {
         if (selectorThread != null && selectorThread.isRunning()){
             stopServer();
         }
 
         System.out.println("Starting GrizzlyServer port number = " + port);
-        
+
         URI u = UriBuilder.fromUri("http://localhost").port(port).build();
         try {
             selectorThread = GrizzlyServerFactory.create(u, adapter);
@@ -91,13 +91,13 @@ public abstract class AbstractGrizzlyServerTester extends TestCase {
             }
         }
     }
-    
+
     public void stopServer() {
         if (selectorThread.isRunning()) {
             selectorThread.stopEndpoint();
         }
     }
-    
+
     @Override
     public void tearDown() {
         stopServer();


### PR DESCRIPTION
Follow below the list of major changes:
- Jersey client upgraded to 1.14
- Parent POM forge-parent upgraded to version 12
- POM cleanup, removed plugins (or just dropped versions) managed in forge-parent
